### PR TITLE
output: update renderer to use shell palettes

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,15 @@ var DefaultChannels = []Channel{
 	{Name: "nixos-unstable", Branch: "nixos-unstable"},
 }
 
+// AvailableChannelNames returns the default channel names as a comma-separated string.
+func AvailableChannelNames() string {
+	names := make([]string, len(DefaultChannels))
+	for i, ch := range DefaultChannels {
+		names[i] = ch.Name
+	}
+	return strings.Join(names, ", ")
+}
+
 // Channel represents a nixpkgs branch that serves as a release channel.
 type Channel struct {
 	Name   string
@@ -44,6 +53,7 @@ func ParsePRInput(input string) (int, error) {
 		return 0, fmt.Errorf("invalid PR input: must be a number or https://github.com/NixOS/nixpkgs/pull/{number}")
 	}
 
+	// Error ignored: regex guarantees matches[1] contains only digits
 	num, _ := strconv.Atoi(matches[1])
 	return num, nil
 }
@@ -56,8 +66,8 @@ func ParseChannels(input string) ([]Channel, error) {
 	}
 
 	requested := make(map[string]bool)
-	for _, p := range strings.Split(input, ",") {
-		name := strings.TrimSpace(p)
+	for _, part := range strings.Split(input, ",") {
+		name := strings.TrimSpace(part)
 		if name != "" {
 			requested[name] = true
 		}
@@ -75,7 +85,7 @@ func ParseChannels(input string) ([]Channel, error) {
 	}
 
 	if len(channels) == 0 {
-		return nil, fmt.Errorf("no matching channels found; available: master, staging-next, nixpkgs-unstable, nixos-unstable-small, nixos-unstable")
+		return nil, fmt.Errorf("no matching channels found; available: %s", AvailableChannelNames())
 	}
 
 	return channels, nil

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -163,19 +163,18 @@ func (c *Checker) checkChannel(ctx context.Context, commit string, ch config.Cha
 	return result
 }
 
-// SortChannelResults sorts channels with present first, then others alphabetically.
+// SortChannelResults sorts channels so present channels come first (preserving
+// their original order), followed by non-present channels sorted alphabetically.
 // Sorts in place and returns the same slice.
 func SortChannelResults(results []ChannelResult) []ChannelResult {
 	sort.SliceStable(results, func(i, j int) bool {
-		// Present channels come first
-		if results[i].Status == StatusPresent && results[j].Status != StatusPresent {
-			return true
+		isPresentI := results[i].Status == StatusPresent
+		isPresentJ := results[j].Status == StatusPresent
+
+		if isPresentI != isPresentJ {
+			return isPresentI
 		}
-		if results[i].Status != StatusPresent && results[j].Status == StatusPresent {
-			return false
-		}
-		// Non-present channels sorted alphabetically
-		if results[i].Status != StatusPresent && results[j].Status != StatusPresent {
+		if !isPresentI {
 			return results[i].Name < results[j].Name
 		}
 		return false

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -13,13 +13,15 @@ import (
 )
 
 const (
-	colorReset  = "\033[0m"
-	colorBold   = "\033[1m"
-	colorGreen  = "\033[32m"
-	colorRed    = "\033[31m"
-	colorYellow = "\033[33m"
-	colorBlue   = "\033[1;34m"
-	colorGray   = "\033[90m"
+	colorReset = "\033[0m"
+	colorBold  = "\033[1m"
+
+	// 256-color palette indices (0-15) for theme compatibility
+	colorGray   = "\033[38;5;8m"  // palette 8: subdued/secondary (draft, author)
+	colorGreen  = "\033[38;5;10m" // palette 10: success/active (open, present)
+	colorBlue   = "\033[38;5;12m" // palette 12: info/completed (merged)
+	colorRed    = "\033[38;5;9m"  // palette 9: error/negative (closed, not present)
+	colorYellow = "\033[38;5;11m" // palette 11: warning/unknown
 
 	iconPresent    = "✓"
 	iconNotPresent = "✗"
@@ -178,23 +180,7 @@ func (r *Renderer) formatChannelStatus(status core.ChannelStatus) string {
 
 // RenderJSON outputs the PR status as pretty-printed JSON.
 func (r *Renderer) RenderJSON(status *core.PRStatus) error {
-	output := struct {
-		PR          int                  `json:"pr"`
-		Title       string               `json:"title,omitempty"`
-		Author      string               `json:"author,omitempty"`
-		State       core.PRState         `json:"state"`
-		MergeCommit string               `json:"merge_commit,omitempty"`
-		Channels    []core.ChannelResult `json:"channels"`
-	}{
-		PR:          status.Number,
-		Title:       status.Title,
-		Author:      status.Author,
-		State:       status.State,
-		MergeCommit: status.MergeCommit,
-		Channels:    status.Channels,
-	}
-
 	encoder := json.NewEncoder(r.writer)
 	encoder.SetIndent("", "  ")
-	return encoder.Encode(output)
+	return encoder.Encode(status)
 }

--- a/tests/render_test.go
+++ b/tests/render_test.go
@@ -74,11 +74,11 @@ func TestRenderTable_WithColor(t *testing.T) {
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "\033[32m") {
-		t.Error("Output should contain green ANSI color code")
+	if !strings.Contains(output, "\033[38;5;10m") {
+		t.Error("Output should contain green palette color code")
 	}
-	if !strings.Contains(output, "\033[1;34m") {
-		t.Error("Output should contain bold blue ANSI color code for merged PR status line")
+	if !strings.Contains(output, "\033[38;5;12m") {
+		t.Error("Output should contain blue palette color code for merged PR status line")
 	}
 }
 


### PR DESCRIPTION
after some thought, i think it's better to play nice with shell palettes and use their color codes, rather than write our own.

This PR changes that behavior in the render layer and accompanying tests, as well as a few minor changes to reduce cognitive load when dealing with the core logic (more function definitions and less code in code paths)